### PR TITLE
Fixed missing #include in wiring.c and added programmer AVRISP mkII

### DIFF
--- a/cores/tiny/wiring.c
+++ b/cores/tiny/wiring.c
@@ -2,6 +2,8 @@
   wiring.c
 */
 
+#include <Arduino.h>
+
 void init(void)
 {
   #if (F_CPU == 8000000L)

--- a/programmers.txt
+++ b/programmers.txt
@@ -4,3 +4,10 @@ usbasp.protocol=usbasp
 usbasp.program.protocol=usbasp
 usbasp.program.tool=avrdude
 usbasp.program.extra_params=-Pusb
+
+avrispmkii.name=AVRISP mkII
+avrispmkii.communication=usb
+avrispmkii.protocol=stk500v2
+avrispmkii.program.protocol=stk500v2
+avrispmkii.program.tool=avrdude
+avrispmkii.program.extra_params=-Pusb


### PR DESCRIPTION
Fixed #12 
Though i think it would be more elegant to move Init() back to main.cpp as it includes only two commands. 

And added AVRISP mkII since i have some clones of this and the're all working fine with Attiny10.
One of them even has a 12V Reset mode for programming Attiny10 with disabled reset pin.. :-)