### PR TITLE
working CI by compiling the examples and  new example (phase in and out)

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -1,0 +1,51 @@
+name: Compile examples
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-examples:
+    name: attiny10:chip=${{matrix.board.fqbn}},clock=${{matrix.clock.freq}}
+    runs-on: ubuntu-latest
+
+    env:
+      platform-name: ATtiny10Core:avr
+      
+      available-adc-true: |
+        - libraries/ATtiny10Core/examples
+
+      available-adc-false: |
+        - libraries/ATtiny10Core/examples/Blink
+        - libraries/ATtiny10Core/examples/LED_Fade_IN_and_OUT
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: 10
+          - fqbn: 9
+          - fqbn: 5
+          - fqbn: 4
+        clock:
+          - freq: 1
+          - freq: 8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Compile 
+        uses: arduino/compile-sketches@main
+        with:
+          platforms: |
+            - source-url: http://www.technoblogy.com/package_technoblogy_index.json
+              name: ${{ env.platform-name }}
+              source-path: "./"
+          sketch-paths: |
+            # It's necessary to jump through some hoops to dynamically generate the env object keys to define the non-universal sketch paths
+            # https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#format
+            ${{ env[format('available-adc-{0}', (matrix.board.fqbn == 5) || (matrix.board.fqbn == 10))] }}
+          fqbn: ${{env.platform-name}}:attiny10:chip=${{matrix.board.fqbn}},clock=${{matrix.clock.freq}}
+            

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,17 @@
+name: Spell Check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # See: https://github.com/codespell-project/actions-codespell/blob/master/README.md
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/libraries/ATtiny10Core/examples/FrequencyGenerator/FrequencyGenerator.ino
+++ b/libraries/ATtiny10Core/examples/FrequencyGenerator/FrequencyGenerator.ino
@@ -2,6 +2,9 @@
   ATtiny10 Frequency Generator
 
   Generates a tone on PB0 whose frequency depends on the voltage on PB1
+  
+  This works on ATtiny10 and ATtiny5.
+  On ATtiny9 and ATtiny4 it does not due the missing ADC function.
 
 */
 

--- a/libraries/ATtiny10Core/examples/LED_Fade_IN_and_OUT/LED_Fade_IN_and_OUT.ino
+++ b/libraries/ATtiny10Core/examples/LED_Fade_IN_and_OUT/LED_Fade_IN_and_OUT.ino
@@ -1,0 +1,36 @@
+/*
+  ATtiny10 Blink
+
+  Fades a LED connected to PB0 repeatedly in and out.
+  Assumes 8 MHz clock
+
+*/
+
+#include <avr/io.h>
+#include <util/delay.h>
+
+int main(void) {
+
+  CCP = 0xD8;
+  CLKPSR = (0 << CLKPS0) | (0 << CLKPS1) | (0 << CLKPS2) | (0 << CLKPS3); // 0000 - system clock is set to 8 MHz
+
+  TCCR0A = (1 << WGM00) | (1 << WGM01) | (1 << COM0B1) | (1 << COM0B0); // PWM, Phase Correct, 10-bit - Compare Output Modes: non-inverted
+  TCCR0B = (0 << WGM02) | (0 << WGM03) | (1 << CS00); // No prescaling: clock source is clk/1
+
+  DDRB |= (1 << PB1);
+
+  int8_t inc = 0;
+  uint16_t duty = 0;
+
+  while (1) {
+
+    if (duty <= 0) {
+      inc = 1;
+    }
+    else if (duty >= 1023) {
+      inc = -1;
+    }
+    _delay_ms(1);
+    OCR0B = (duty += inc);
+  }
+}


### PR DESCRIPTION
Hello,
thanks for the arduino core for the small ATtiny10´s :-)

This PR does 4 things: 

- Add's the example contributed here: https://github.com/technoblogy/attiny10core/issues/3
- Add's CI by compiling all the examples. But the FrequencyGenerator only for ATtiny10 and ATtiny5
- Modify the FrequencyGenerator to add a note about the working ATtiny10 and ATtiny5.
- Add's CI by spell checking

The CI is using the github actions to compile all examples for all variants with both frequency settings.  This makes 8 so called jobs, and each job is then compiling all examples, but its leaving the FrequencyGenerator out for the ones with no ADC.

It will run on every push or pull and automatically perform the check.

A full run of the CI can be seen here: https://github.com/designer2k2/attiny10core/actions/runs/3905332352

Deep link into a job: https://github.com/designer2k2/attiny10core/actions/runs/3905332352/jobs/6672199008#step:3:77